### PR TITLE
feat: karma-osx-reporter setup

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
       'karma-phantomjs-launcher',
       'karma-chrome-launcher',
       'karma-firefox-launcher',
+      'karma-osx-reporter',
       //'karma-safari-launcher'  // npm install karma-safari-launcher
     ],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-qunit": "~0.0.3",
     "karma-coverage": "~0.0.3",
     "karma-phantomjs-launcher": "~0.0.2",
+    "karma-osx-reporter": "~0.0.4",
     "express-namespace": "~0.1.1",
     "request": "~2.27.0",
     "connect-livereload": "~0.3.1",

--- a/tasks/options/karma.js
+++ b/tasks/options/karma.js
@@ -2,7 +2,7 @@ module.exports = {
   options: {
     configFile: 'karma.conf.js',
     browsers: ['Chrome'],
-    reporters: ['coverage', 'dots']
+    reporters: ['coverage', 'dots', 'osx']
   },
   ci: {
     singleRun: true,


### PR DESCRIPTION
karma-osx-reporter setup

works both with `grunt karma:test` and `grunt karma:ci`
